### PR TITLE
Added a new friendly-fire feature. The new command is /f friendlyfire…

### DIFF
--- a/src/main/java/com/massivecraft/factions/Faction.java
+++ b/src/main/java/com/massivecraft/factions/Faction.java
@@ -55,6 +55,10 @@ public interface Faction extends EconomyParticipator {
 
     public boolean getPeacefulExplosionsEnabled();
 
+    public void setFriendlyFire(boolean friendlyFire);
+
+    public boolean getFriendlyFire();
+
     public boolean noExplosionsInTerritory();
 
     public boolean isPermanent();

--- a/src/main/java/com/massivecraft/factions/cmd/CmdFriendlyFire.java
+++ b/src/main/java/com/massivecraft/factions/cmd/CmdFriendlyFire.java
@@ -1,0 +1,30 @@
+package com.massivecraft.factions.cmd;
+
+import com.massivecraft.factions.zcore.util.TL;
+
+/**
+ * Created by Julio on 4/5/2016.
+ */
+public class CmdFriendlyFire extends FCommand {
+
+    public CmdFriendlyFire(){
+        aliases.add("friendlyfire");
+        aliases.add("ff");
+
+        senderMustBeModerator = true;
+        senderMustBePlayer = true;
+    }
+
+    @Override
+    public void perform() {
+
+        boolean friendlyFire = myFaction.getFriendlyFire();
+        myFaction.setFriendlyFire(!friendlyFire);
+        myFaction.msg(TL.COMMAND_FRIENDLY_FIRE_TOGGLED, fme.describeTo(myFaction, true), (myFaction.getFriendlyFire() ? "en":"dis") + "abled");
+    }
+
+    @Override
+    public TL getUsageTranslation() {
+        return TL.COMMAND_FRIENDLY_FIRE;
+    }
+}

--- a/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
+++ b/src/main/java/com/massivecraft/factions/cmd/FCmdRoot.java
@@ -68,6 +68,7 @@ public class FCmdRoot extends FCommand {
     public CmdClaimLine cmdClaimLine = new CmdClaimLine();
     public CmdTop cmdTop = new CmdTop();
     public CmdAHome cmdAHome = new CmdAHome();
+    public CmdFriendlyFire cmdFriendlyFire = new CmdFriendlyFire();
 
     public FCmdRoot() {
         super();
@@ -151,6 +152,7 @@ public class FCmdRoot extends FCommand {
         this.addSubCommand(this.cmdClaimLine);
         this.addSubCommand(this.cmdTop);
         this.addSubCommand(this.cmdAHome);
+        this.addSubCommand(this.cmdFriendlyFire);
     }
 
     @Override

--- a/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
+++ b/src/main/java/com/massivecraft/factions/listeners/FactionsEntityListener.java
@@ -393,8 +393,8 @@ public class FactionsEntityListener implements Listener {
             return true;
         }
 
-        // You can never hurt faction members or allies
-        if (relation.isMember() || relation.isAlly()) {
+        // You can only hurt faction members when friendly fire is toggled, can never hurt allies
+        if ((relation.isMember() && !attackFaction.getFriendlyFire()) || relation.isAlly()) {
             if (notify) {
                 attacker.msg(TL.PLAYER_PVP_CANTHURT, defender.describeTo(attacker));
             }

--- a/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
+++ b/src/main/java/com/massivecraft/factions/zcore/persist/MemoryFaction.java
@@ -25,6 +25,7 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
     protected String id = null;
     protected boolean peacefulExplosionsEnabled;
     protected boolean permanent;
+    protected boolean friendlyFire;
     protected String tag;
     protected String description;
     protected boolean open;
@@ -137,6 +138,14 @@ public abstract class MemoryFaction implements Faction, EconomyParticipator {
 
     public void setPeacefulExplosionsEnabled(boolean val) {
         peacefulExplosionsEnabled = val;
+    }
+
+    public void setFriendlyFire(boolean friendlyFire){
+        this.friendlyFire = friendlyFire;
+    }
+
+    public boolean getFriendlyFire(){
+        return this.friendlyFire;
     }
 
     public boolean getPeacefulExplosionsEnabled() {

--- a/src/main/java/com/massivecraft/factions/zcore/util/TL.java
+++ b/src/main/java/com/massivecraft/factions/zcore/util/TL.java
@@ -176,6 +176,9 @@ public enum TL {
     COMMAND_DISBAND_HOLDINGS("<i>You have been given the disbanded faction's bank, totaling %1$s."),
     COMMAND_DISBAND_DESCRIPTION("Disband a faction"),
 
+    COMMAND_FRIENDLY_FIRE("Toggle friendly fire"),
+    COMMAND_FRIENDLY_FIRE_TOGGLED("%1$s<i> has %2$s<i> friendly fire"),
+
     COMMAND_FWARP_CLICKTOWARP("Click to warp!"),
     COMMAND_FWARP_COMMANDFORMAT("<i>/f warp <warpname>"),
     COMMAND_FWARP_WARPED("<i>Warped to <a>%1$s"),


### PR DESCRIPTION
… (or as an alias /f ff). Using this will toggle friendly fire. When friendly fire is enabled, you will be able to damage your teammates and vice-versa. This applies to the whole faction.